### PR TITLE
Defect #3037018 - Exception is being thrown when running test runner pipeline with variables and not configuring the variables

### DIFF
--- a/src/TestRunnerStartTask.ts
+++ b/src/TestRunnerStartTask.ts
@@ -375,9 +375,19 @@ export class TestRunnerStartTask extends BaseTask {
               definedParameters
           );
 
-      const executionId = parameters.find(parameter => parameter.name === 'executionId').value;
-      const suiteRunId = parameters.find(parameter => parameter.name === 'suiteRunId').value;
-      this.testToConvert = parameters.find(parameter => parameter.name === 'testsToRun').value;
+      const executionIdCIParameter = parameters.find(parameter => parameter.name === 'executionId');
+      const suiteRunIdCIParameter = parameters.find(parameter => parameter.name === 'suiteRunId');
+      const testsToConvert = parameters.find(parameter => parameter.name === 'testsToRun');
+
+      let executionId: string;
+      let suiteRunId: string;
+      if (executionIdCIParameter === undefined || suiteRunIdCIParameter === undefined || testsToConvert === undefined) {
+          this.logger.info("Missing executionId or suiteRunId or testsToRun parameters, meaning that the task was not triggered by a suite run action from Octane.");
+      } else {
+          executionId = executionIdCIParameter.value;
+          suiteRunId = suiteRunIdCIParameter.value;
+          this.testToConvert = testsToConvert.value;
+      }
 
       this.logger.debug("testsToRun: " + this.testToConvert);
       this.logger.info("executionId: " + executionId);

--- a/src/TestRunnerStartTask.ts
+++ b/src/TestRunnerStartTask.ts
@@ -379,15 +379,13 @@ export class TestRunnerStartTask extends BaseTask {
       const suiteRunIdCIParameter = parameters.find(parameter => parameter.name === 'suiteRunId');
       const testsToConvert = parameters.find(parameter => parameter.name === 'testsToRun');
 
-      let executionId: string;
-      let suiteRunId: string;
       if (executionIdCIParameter === undefined || suiteRunIdCIParameter === undefined || testsToConvert === undefined) {
           this.logger.info("Missing executionId or suiteRunId or testsToRun parameters, meaning that the task was not triggered by a suite run action from Octane.");
-      } else {
-          executionId = executionIdCIParameter.value;
-          suiteRunId = suiteRunIdCIParameter.value;
-          this.testToConvert = testsToConvert.value;
       }
+
+      let executionId: string = executionIdCIParameter === undefined ? undefined : executionIdCIParameter.value;
+      let suiteRunId: string =  suiteRunIdCIParameter === undefined ? undefined : suiteRunIdCIParameter.value;
+      this.testToConvert = testsToConvert === undefined ? undefined : testsToConvert.value;
 
       this.logger.debug("testsToRun: " + this.testToConvert);
       this.logger.info("executionId: " + executionId);

--- a/src/TestRunnerStartTask.ts
+++ b/src/TestRunnerStartTask.ts
@@ -375,17 +375,17 @@ export class TestRunnerStartTask extends BaseTask {
               definedParameters
           );
 
-      const executionIdCIParameter = parameters.find(parameter => parameter.name === 'executionId');
-      const suiteRunIdCIParameter = parameters.find(parameter => parameter.name === 'suiteRunId');
-      const testsToConvert = parameters.find(parameter => parameter.name === 'testsToRun');
+      const executionIdCIParameter = parameters.find(parameter => parameter.name === 'executionId')?.value;
+      const suiteRunIdCIParameter = parameters.find(parameter => parameter.name === 'suiteRunId')?.value;
+      const testsToConvertCIParameter = parameters.find(parameter => parameter.name === 'testsToRun')?.value;
 
-      if (executionIdCIParameter === undefined || suiteRunIdCIParameter === undefined || testsToConvert === undefined) {
+      if (!executionIdCIParameter || !suiteRunIdCIParameter || !testsToConvertCIParameter) {
           this.logger.info("Missing executionId or suiteRunId or testsToRun parameters, meaning that the task was not triggered by a suite run action from Octane.");
       }
 
-      let executionId: string = executionIdCIParameter === undefined ? undefined : executionIdCIParameter.value;
-      let suiteRunId: string =  suiteRunIdCIParameter === undefined ? undefined : suiteRunIdCIParameter.value;
-      this.testToConvert = testsToConvert === undefined ? undefined : testsToConvert.value;
+      const executionId: string = executionIdCIParameter;
+      const suiteRunId: string = suiteRunIdCIParameter;
+      this.testToConvert = testsToConvertCIParameter ;
 
       this.logger.debug("testsToRun: " + this.testToConvert);
       this.logger.info("executionId: " + executionId);


### PR DESCRIPTION
### Backlog item:
- https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3037018

### Description 
- In case the pipeline was run from Azure DevOps or from Octane as a pipeline and not a by running a test suite, an exception was thrown because we were trying to get the value of undefined.
- I added a check if the `executionId`, `suiteRunId` or `testsToRun` parameters are undefined and if yes log a informative message and only get the values if they have one.