### PR TITLE
Defect #3216073 - Decode spaces in class and package names for UFT tests 

### DIFF
--- a/src/EndTask.ts
+++ b/src/EndTask.ts
@@ -370,10 +370,14 @@ export class EndTask extends BaseTask {
         }
     }
 
+    private formatClassNameWithSpaces(className: string): string {
+        return className.replace(/%20/g, ' ');
+    }
+
     private createPackageName(className: string): string {
         let packageName: string;
         const rootDirectory = process.env.BUILD_SOURCESDIRECTORY;
-        className = className.replace("file:///", "");
+        className = this.formatClassNameWithSpaces(className.replace("file:///", ""));
         packageName = path.relative(rootDirectory, className);
         const parts = packageName.split(/[\/\\]/);
         packageName = parts.join("/");
@@ -383,7 +387,7 @@ export class EndTask extends BaseTask {
     private createClassName(className: string, testName: string): string {
         let newClassName: string;
         const rootDirectory = process.env.BUILD_SOURCESDIRECTORY;
-        className = className.replace("file:///", "");
+        className = this.formatClassNameWithSpaces(className.replace("file:///", ""));
         let firstPart = path.relative(rootDirectory, className);
         if (firstPart) {
             const parts = firstPart.split(/[\/\\]/);


### PR DESCRIPTION
### Backlog item:
- https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3216073

### Description:
- Added a new method that decodes spaces in class and package names. This is needed for the names to appear correctly in Octane and the tests can be ran using a test runner. 