### PR TITLE
story#3054002 - Release version 26.3.0

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@microfocus/alm-octane-js-rest-sdk": "26.2.1",
-        "@microfocus/alm-octane-test-result-convertion": "^25.2.3",
+        "@microfocus/alm-octane-test-result-convertion": "^26.3.0",
         "@types/node": "12.0.12",
         "@types/q": "1.5.2",
         "adm-zip": "^0.5.16",
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@microfocus/alm-octane-test-result-convertion": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@microfocus/alm-octane-test-result-convertion/-/alm-octane-test-result-convertion-25.2.3.tgz",
-      "integrity": "sha512-iCCcAws6qViZW6O6xHFePcBRabu08UO5r5D7mzn+yqWfi3/ZKjhl+CfLqTJo4v/dbXsMoVDijGRdN+CYDaU2OQ==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@microfocus/alm-octane-test-result-convertion/-/alm-octane-test-result-convertion-26.3.0.tgz",
+      "integrity": "sha512-sAENqA6qJ6HPUdH/OVu9bVwvw8kxNH4p5avvog6Zguqnpcs+oo4zys/Q4/dnD9HuR7bOHCbxuDCmLPC8PLApbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "xml-escape": "^1.1.0",

--- a/src/package.json
+++ b/src/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@microfocus/alm-octane-js-rest-sdk": "26.2.1",
-    "@microfocus/alm-octane-test-result-convertion": "^25.2.3",
+    "@microfocus/alm-octane-test-result-convertion": "^26.3.0",
     "@types/node": "12.0.12",
     "@types/q": "1.5.2",
     "adm-zip": "^0.5.16",

--- a/templates/public/Tasks/EndTask/task.json
+++ b/templates/public/Tasks/EndTask/task.json
@@ -12,7 +12,7 @@
   "demands": [],
   "version": {
     "Major": "26",
-    "Minor": "1",
+    "Minor": "3",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.170.1",
@@ -59,6 +59,25 @@
       "label": "Github repository connection",
       "required": false,
       "helpMarkDown": "Github repository connection"
+    },
+    {
+      "name": "CodeCoverageType",
+      "type": "pickList",
+      "label": "Code coverage report file type",
+      "required": false,
+      "helpMarkDown": "Select which kind of report file should the integration look for.\n",
+      "options": {
+        "JACOCOXML": "JACOCO",
+        "LCOV": "LCOV",
+        "SONAR_REPORT": "SONAR"
+      }
+    },
+    {
+      "name": "SonarQubeServiceConnection",
+      "type": "connectedService:sonarqube",
+      "label": "SonarQube service connection",
+      "required": false,
+      "helpMarkDown": "SonarQube service connection used for SONAR_REPORT coverage retrieval"
     }
   ],
   "execution": {

--- a/templates/public/Tasks/GetParamsTask/task.json
+++ b/templates/public/Tasks/GetParamsTask/task.json
@@ -9,7 +9,7 @@
   "demands": [],
   "version": {
     "Major": "26",
-    "Minor": "1",
+    "Minor": "3",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.170.1",

--- a/templates/public/Tasks/StartTask/task.json
+++ b/templates/public/Tasks/StartTask/task.json
@@ -12,7 +12,7 @@
   "demands": [],
   "version": {
     "Major": "26",
-    "Minor": "1",
+    "Minor": "3",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.170.1",

--- a/templates/public/Tasks/TestRunnerStartTask/task.json
+++ b/templates/public/Tasks/TestRunnerStartTask/task.json
@@ -12,7 +12,7 @@
   "demands": [],
   "version": {
     "Major": "26",
-    "Minor": "1",
+    "Minor": "3",
     "Patch": "0"
   },
   "minimumAgentVersion": "2.170.1",

--- a/templates/public/vss-extension.json
+++ b/templates/public/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "alm-octane-integration-public",
-  "version": "26.1.0",
+  "version": "26.3.0",
   "name": "CSDP/SDM Integration Extension",
   "description": "An Azure DevOps extension that supplies the required entities for establishing an integration with CSDP/SDM.",
   "publisher": "almoctane",


### PR DESCRIPTION
### Backlog item:
- User story [#3054002](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3054002)

### Description:
- Release `octane-azure-devops-extension` version `26.3.0` by: 
  - increasing public tasks and extension versions
  - adding the inputs for the code coverage feature, to the public extension as well
  - updating `alm-octane-test-result-conversion` dependency to `26.3.0` 