### PR TITLE
Defect #3220037 - Test name is not correct if there is an error with the UFT tool

### DIFF
--- a/src/EndTask.ts
+++ b/src/EndTask.ts
@@ -207,7 +207,7 @@ export class EndTask extends BaseTask {
                     const testRuns = Array.isArray(jsonObj.test_result.test_runs.test_run) ? jsonObj.test_result.test_runs.test_run : [jsonObj.test_result.test_runs.test_run];
                     for (const run of testRuns) {
                         const classPath = run.class;
-                        const testName = run.name;
+                        const testName = this.extractTestName(run.name);
 
                         const packageName = this.createPackageName(classPath);
                         run.class = this.createClassName(classPath, testName);
@@ -368,6 +368,11 @@ export class EndTask extends BaseTask {
         } else {
             return this.jobStatus;
         }
+    }
+
+    private extractTestName(name: string): string {
+        const lastSlashIndex = name.lastIndexOf('\\');
+        return lastSlashIndex !== -1 ? name.substring(lastSlashIndex + 1) : name;
     }
 
     private formatClassNameWithSpaces(className: string): string {


### PR DESCRIPTION
### Backlog item:
- https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3220037

### Description:
- When there was error in the UFT tool the test name was incorrect in Octane. 
- I handled that case so the test name is always correct in Octane.