### PR TITLE
defect#3223032 - Support backwards compatibility for test results injection flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ If your pipeline uses test results injection (JUnit/UFT One/NUnit), you must upd
 
 Please follow the exact steps described in [Chapter 8.1](#81-displaying-junituft-onenunit-test-results-into-the-product-using-yml-editor).
 
-Pipelines that are not updated as described in Chapter 8.1 may no longer display test results in the product.
+Pipelines that are not updated as described in Chapter 8.1 should still display test results in the product, since a fallback mechanism is in place,
+but we highly recommend updating your pipelines to use the new test results injection mechanism.
 
 ## 4. Requirements
 

--- a/src/EndTask.ts
+++ b/src/EndTask.ts
@@ -50,6 +50,7 @@ import {CoverageProviderFactory} from "./services/code_coverage/factory/Coverage
 import {OctaneCoverageClient} from "./services/code_coverage/clients/OctaneCoverageClient";
 import {CodeCoverageOrchestrator} from "./services/code_coverage/orchestrator/CodeCoverageOrchestrator";
 import {ICoverageProvider} from "./services/code_coverage/providers/ICoverageProvider";
+import {TestResultsBuilder} from "./services/test_results/TestResultsBuilder";
 
 const parser = new XMLParser({
     ignoreAttributes: false,
@@ -108,20 +109,40 @@ export class EndTask extends BaseTask {
                     const frameworkType = stringToFrameworkType(framework)
                     this.logger.info(`The framework type is: ${frameworkType}`);
 
-                    const globPattern = process.env.UNIT_TEST_RESULTS_GLOB_PATTERN || '**/*.xml';
-                    this.logger.info("global pattern ", globPattern);
+                    const explicitGlobPattern: string = process.env.UNIT_TEST_RESULTS_GLOB_PATTERN?.trim();
+                    const hasExplicitGlobPattern: boolean = !!explicitGlobPattern;
 
-                    const files = glob.sync(globPattern);
-                    this.logger.info("The test result files are: " + files + " with length: " + files.length);
+                    if (hasExplicitGlobPattern) {
+                        this.logger.info("Using UNIT_TEST_RESULTS_GLOB_PATTERN: " + explicitGlobPattern);
 
-                    if (files.length === 0 && !cucumberReportsPath) {
-                        this.logger.warn("No test results");
-                        await this.buildCIAndSendCIEvent(api, ws, testResultExpected);
-                        return;
+                        const files: string[] = glob.sync(explicitGlobPattern);
+                        this.logger.info("The test result files are: " + files + " with length: " + files.length);
+
+                        if (files.length === 0 && !cucumberReportsPath) {
+                            this.logger.warn("No test results");
+                            await this.buildCIAndSendCIEvent(api, ws, testResultExpected);
+                            return;
+                        }
+
+                        testResults = await this.handleTestResultInjection(cucumberReportsPath, files, buildConfig, framework, frameworkType);
+                        this.logger.info("The converted test results to Octane XML are: " + testResults);
+                    } else {
+                        // Backward compatibility path for older pipelines that relied on ADO Test API collection.
+                        this.logger.warn("UNIT_TEST_RESULTS_GLOB_PATTERN is not set. Falling back to legacy Azure DevOps Test API collection.");
+
+                        testResults = await TestResultsBuilder.getTestsResultsByBuildId(
+                            api,
+                            this.projectName,
+                            parseInt(this.buildId),
+                            this.instanceId,
+                            this.jobFullName,
+                            cucumberReportsPath,
+                            this.logger
+                        );
+
+                        this.logger.debug("Returned test results: " + testResults);
+                        this.logger.info("Legacy flow produced " + testResults.length + " test result payload(s).");
                     }
-
-                    testResults = await this.handleTestResultInjection(cucumberReportsPath, files, buildConfig, framework, frameworkType);
-                    this.logger.info("The converted test results to Octane XML are: " + testResults);
 
                     for (const testResult of testResults) {
                         if (testResult && testResult.length > 0) {

--- a/src/services/test_results/TestResultsBuilder.ts
+++ b/src/services/test_results/TestResultsBuilder.ts
@@ -236,25 +236,13 @@ export class TestResultsBuilder {
         let unitTestResults: Array<UnitResultElement> = [];
         testResults.forEach(element => {
             logger.debug("Azure test input - automatedTestStorage: " + element.automatedTestStorage + " , automatedTestName: " + element.automatedTestName);
-            let packageName =
-                element.automatedTestStorage && element.automatedTestStorage.indexOf('.') > 0 ?
-                    element.automatedTestStorage.substring(0,element.automatedTestStorage.lastIndexOf('.')) :
-                    element.automatedTestStorage;
-            packageName = xmlescape(packageName || "");
-            if (packageName.length > 255) {
-                logger.error('Package name is longer than 255 chars: ' + packageName);
-                return;
-            }
+            let packageName = xmlescape("");
             let name = xmlescape(element.automatedTestName || "");
             if (name.length > 255) {
                 logger.error('Test name is longer than 255 chars: ' + name);
                 return;
             }
-            let classname =
-                element.automatedTestStorage && element.automatedTestStorage.indexOf('.') > 0 ?
-                    element.automatedTestStorage.substring(element.automatedTestStorage.lastIndexOf('.') + 1) :
-                    element.automatedTestStorage;
-            classname = xmlescape(classname || "");
+            let classname = xmlescape(element.automatedTestStorage || "");
             if (classname.length > 255) {
                 logger.error('Classname name is longer than 255 chars: ' + classname);
                 return;


### PR DESCRIPTION
### Backlog item:
- Defect [#3223032](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3223032)

### Description:
- Currently, backwards compatibility is violated for test results injection flow, due to the fact that, in case we don't configure: 
```
env:
    UNIT_TEST_RESULTS_GLOB_PATTERN: ${{ parameters.unitTestResultsGlobPattern }}
```

the fallback value might take xml files that are not test results and try to process them and fail in the process, resulting in complete failure on the test results injection flow.

- In case customers don't configure the previously mentioned parameter, we need to fetch the test results using the Azure DevOps API and convert them to Octane format